### PR TITLE
make symbolize keys explicit on call to JSON parser

### DIFF
--- a/lib/resque-history/plugins/history.rb
+++ b/lib/resque-history/plugins/history.rb
@@ -10,10 +10,10 @@ module Resque
       end
 
       def on_failure_history(exception, *args)
-        Resque.redis.lpush(HISTORY_SET_NAME, {"class"=>"#{self}",
-                                              "time"=>Time.now.strftime("%Y-%m-%d %H:%M"),
-                                              "args"=>args,
-                                              "error"=>exception.message
+        Resque.redis.lpush(HISTORY_SET_NAME, {:class => "#{self}",
+                                              :time => Time.now.strftime("%Y-%m-%d %H:%M"),
+                                              :args => args,
+                                              :error => exception.message
         }.to_json)
 
         if Resque.redis.llen(HISTORY_SET_NAME) > maximum_history_size
@@ -29,10 +29,10 @@ module Resque
 
       def after_perform_history(*args)
         elapsed_seconds = (Time.now - @start_time).to_i
-        Resque.redis.lpush(HISTORY_SET_NAME, {"class"=>"#{self}",
-                                              "args"=>args,
-                                              "time"=>Time.now.strftime("%Y-%m-%d %H:%M"),
-                                              "execution"=>elapsed_seconds
+        Resque.redis.lpush(HISTORY_SET_NAME, {:class => "#{self}",
+                                              :args => args,
+                                              :time => Time.now.strftime("%Y-%m-%d %H:%M"),
+                                              :execution =>elapsed_seconds
         }.to_json)
 
         if Resque.redis.llen(HISTORY_SET_NAME) > maximum_history_size

--- a/lib/resque-history/server/views/history.erb
+++ b/lib/resque-history/server/views/history.erb
@@ -22,12 +22,12 @@
       <th>Execution</th>
     </tr>
     <% history.each do |history| %>
-        <% j = JSON.parse(history) %>
+        <% j = JSON.parse(history, :symbolize_keys => true) %>
         <tr class='<%= j["error"].nil? ? "" : "failure" %>' >
-          <td class='queue'><%= j["class"] %></td>
-          <td class='args'><%= j["args"] %></td>
-          <td class='args'><%= j["time"] %></td>
-          <td class='args'><%= format_execution(j["execution"]) %></td>
+          <td class='queue'><%= j[:class] %></td>
+          <td class='args'><%= j[:args] %></td>
+          <td class='args'><%= j[:time] %></td>
+          <td class='args'><%= format_execution(j[:execution]) %></td>
         </tr>
     <% end %>
   </table>


### PR DESCRIPTION
- because you can't be sure what people will set as their defaults for JSON better to be explicit
- this should have no perceivable difference, but it will not break when people mess with JSON defaults in their apps
