### PR TITLE
Update arg display to be closer to resque-web's failed tab

### DIFF
--- a/lib/resque-history/server/views/history.erb
+++ b/lib/resque-history/server/views/history.erb
@@ -22,7 +22,7 @@
       <th>Execution</th>
     </tr>
     <% history.each do |history| %>
-        <% j = JSON.parse(history, :symbolize_names => true) %>
+      <% j = JSON.parse(history, :symbolize_names => true, :symbolize_keys => true) %>
         <tr class='<%= j[:error].nil? ? "" : "failure" %>' >
           <td class='queue'><%= j[:class] %></td>
           <td class='args'><pre><%= j[:args] ? show_args(j[:args]) : '' %></pre></td>


### PR DESCRIPTION
- Updated to use the show_args helper to format job arguments
- Also used <pre> tags like the failed tab does so that arguments get their own lines.
- Passed both versions of symbolize to JSON.parse because when using yajl with the JSON gem there is an 
  incompatibility. 
- Passing both is forward and backwards compatibile but hopefully the fix will get merged into yajl-ruby.
