### PR TITLE
support time localization

### DIFF
--- a/lib/resque-history/plugins/history.rb
+++ b/lib/resque-history/plugins/history.rb
@@ -11,7 +11,7 @@ module Resque
 
       def on_failure_history(exception, *args)
         Resque.redis.lpush(HISTORY_SET_NAME, {:class => "#{self}",
-                                              :time => Time.now.strftime("%Y-%m-%d %H:%M"),
+                                              :time => Time.now.strftime("%Y-%m-%d %H:%M:%S %z"),
                                               :args => args,
                                               :error => exception.message
         }.to_json)


### PR DESCRIPTION
The current version show the "relatized time" based on the timestamp that is stored in redis. However, this current timestamp carries no timezone information. So, if you have a resque server running in California, but are viewing the logs in Chicago (just as an example :smile:), then the timestamp are always X hours off.
